### PR TITLE
Change sed delimiters to allow IP address ranges

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,9 @@ services:
 #      - ENABLE_ACCESS_LOG=true
 #      - ENABLE_BASIC_AUTH=true
 #      - BASIC_AUTH_BASE64=IyB0ZXN0OnRlc3QKdGVzdDokYXByMSRidWN0akk2diRpaWkyY25ObTRsdUpNc3E4YWN2UXYuCg==
+#      - ALLOW=10.0.0.0/16
+#      - DENY=10.0.0.0/16
+#      - SET_REAL_IP_FROM=10.0.0.0/16
 #    volumes:
 #       - ./testing/passwords:/etc/secrets/htpasswd
     depends_on:

--- a/start.sh
+++ b/start.sh
@@ -63,7 +63,7 @@ fi
 if [ -n "${SET_REAL_IP_FROM+1}" ]; then
   echo "Setting trustable proxy..."
   sed -i "s/#set_real_ip_from/set_real_ip_from/g;" /etc/nginx/conf.d/proxy.conf
-  sed -i "s/{{SET_REAL_IP_FROM}}/${SET_REAL_IP_FROM}/g;" /etc/nginx/conf.d/proxy.conf
+  sed -i "s={{SET_REAL_IP_FROM}}=${SET_REAL_IP_FROM}=g;" /etc/nginx/conf.d/proxy.conf
 fi
 
 # Setting header name to read user ip from
@@ -90,14 +90,14 @@ fi
 if [ -n "${ALLOW+1}" ]; then
   echo "Allowing defined ip..."
   sed -i "s/#allow/allow/g;" /etc/nginx/conf.d/proxy.conf
-  sed -i "s/{{ALLOW}}/${ALLOW}/g;" /etc/nginx/conf.d/proxy.conf
+  sed -i "s={{ALLOW}}=${ALLOW}=g;" /etc/nginx/conf.d/proxy.conf
 fi
 
 # Denying access
 if [ -n "${DENY+1}" ]; then
   echo "Denying defined ip..."
   sed -i "s/#deny/deny/g;" /etc/nginx/conf.d/proxy.conf
-  sed -i "s/{{DENY}}/${DENY}/g;" /etc/nginx/conf.d/proxy.conf
+  sed -i "s={{DENY}}=${DENY}=g;" /etc/nginx/conf.d/proxy.conf
 fi
 
 # allow/deny default behavior


### PR DESCRIPTION
Change sed delimiters to allow IP address ranges for ALLOW, DENY, and SET_REAL_IP_FROM.

With `/` as delimiter the sed substitutions don't support setting IP address ranges (eg. `ALLOW=10.0.0.0/16`) because it breaks the sed expression:

`"s/{{ALLOW}}/${ALLOW}/g;"` becomes `"s/{{ALLOW}}/ALLOW=10.0.0.0/16/g;"` which is invalid.