### PR TITLE
Use the map directive to set the X-Forwarded-Proto header.

### DIFF
--- a/nginx/proxy_nossl.conf
+++ b/nginx/proxy_nossl.conf
@@ -3,6 +3,11 @@ map $http_upgrade $connection_upgrade {
   '' close;
 }
 
+map $http_x_forwarded_proto $x_forwarded_proto {
+  default $http_x_forwarded_proto;
+  '' $scheme;
+}
+
 upstream target_service {
   server {{TARGET_SERVICE}};
 }
@@ -14,13 +19,6 @@ server {
   location /healthcheck {
       add_header Content-Type text/plain;
       return 200 'health check ok';
-  }
-
-  if ($http_x_forwarded_proto != "") {
-      set $x_forwarded_proto $http_x_forwarded_proto;
-  }
-  if ($x_forwarded_proto = "") {
-      set $x_forwarded_proto $scheme;
   }
 
   location / {

--- a/nginx/proxy_ssl.conf
+++ b/nginx/proxy_ssl.conf
@@ -3,6 +3,11 @@ map $http_upgrade $connection_upgrade {
   '' close;
 }
 
+map $http_x_forwarded_proto $x_forwarded_proto {
+  default $http_x_forwarded_proto;
+  '' $scheme;
+}
+
 upstream target_service {
   server {{TARGET_SERVICE}};
 }
@@ -49,7 +54,7 @@ server {
       proxy_set_header        Host $host;
       proxy_set_header        X-Real-IP $remote_addr;
       proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header        X-Forwarded-Proto $scheme;
+      proxy_set_header        X-Forwarded-Proto $x_forwarded_proto;
       proxy_set_header        X-Forwarded-Host $http_host;
       proxy_set_header        Upgrade $http_upgrade;
       proxy_set_header        Connection $connection_upgrade;


### PR DESCRIPTION
Use the `map` instruction to set the `$x_forwarded_proto` variable instead of `if` instructions because it seems to be a cleaner solution than my previous approach and Nginx recommends to avoid `if` if possible: <https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/>